### PR TITLE
`RabbitMQServer._terminate_process()`: fix `TypeError` raised from string formatting

### DIFF
--- a/testing/rabbitmq.py
+++ b/testing/rabbitmq.py
@@ -155,7 +155,7 @@ class RabbitMQServer(Database):
         if alive:
             # send SIGKILL
             for p in alive:
-                print("process {} survived SIGTERM; trying SIGKILL" % p)
+                print("process {} survived SIGTERM; trying SIGKILL".format(p))
                 try:
                     p.kill()
                 except psutil.NoSuchProcess:
@@ -164,7 +164,7 @@ class RabbitMQServer(Database):
             if alive:
                 # give up
                 for p in alive:
-                    print("process {} survived SIGKILL; giving up" % p)
+                    print("process {} survived SIGKILL; giving up".format(p))
                     raise RuntimeError("*** failed to shutdown child process ***")
 
     @staticmethod


### PR DESCRIPTION
When issuing a `SIGKILL` is warranted, the `RabbitMQServer._terminate_process()` method attempts to print two messages that end up raising a `TypeError` exception due to the mixing of string formatting methods:

```shell
env/lib/python3.6/site-packages/testing/rabbitmq.py:138: in terminate
    RabbitMQServer._terminate_process(self.child_process.pid)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pid = 16463
    @staticmethod
    def _terminate_process(pid):
        """Tries hard to terminate and ultimately kill all the children of this process."""
        timeout = 10
        proc = psutil.Process(pid)
        procs = [proc] + proc.children(recursive=True)
        # send SIGTERM
        for p in procs:
            try:
                p.terminate()
            except psutil.NoSuchProcess:
                pass
        gone, alive = psutil.wait_procs(procs, timeout=timeout)
        if alive:
            # send SIGKILL
            for p in alive:
>               print("process {} survived SIGTERM; trying SIGKILL" % p)
E               TypeError: not all arguments converted during string formatting
env/lib/python3.6/site-packages/testing/rabbitmq.py:158: TypeError
```

This PR modifies those `print()` statements to use the `format()` method.